### PR TITLE
Fix: crates checkout

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,9 @@
 #https://github.com/rust-lang/rust/blob/master/config.toml.example
 
+[net]
+# Required to checkout some git submodules like `xz`submodule. Check `lzma-sys` crate.
+git-fetch-with-cli = true
+
 [target.'cfg(target_os="android")']
 runner = ["./scripts/android_runner.sh"]
 rustflags = [


### PR DESCRIPTION
The `xz` git submodule  cannot be checkout during build process without `git-fetch-with-cli`.