### PR TITLE
CMake improvement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ insert_final_newline = true
 [**/CMakeLists.txt]
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[{*.yml, *.yaml}]
+indent_size = 2

--- a/.github/run_cmake.sh
+++ b/.github/run_cmake.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#For reusable purpose
+
+# Path to CMake
+CMAKE_BIN=${ANDROID_HOME}/cmake/${CMAKE_VERSION}/bin/cmake
+
+# Path to CMake output directory
+NINJA_OUTPUT=${GITHUB_WORKSPACE}/build/android/${ABI}
+
+# We should create the directory before run CMake
+mkdir -p ${NINJA_OUTPUT}
+
+# Generate Ninja
+# see https://developer.android.com/studio/projects/configure-cmake#call-cmake-cli
+# Or open any 'build_command.txt' inside Android Gradle module .cxx/cmake/${ANDROID_BUILD_VARIANT}/${ABI}/ 
+${CMAKE_BIN} \
+    -H${GITHUB_WORKSPACE} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=${ANDROID_HOME}/ndk/${NDK_VERSION}/build/cmake/android.toolchain.cmake \
+    -DANDROID_ABI=${ABI} \
+    -DANDROID_NDK=${ANDROID_HOME}/ndk/${NDK_VERSION} \
+    -DANDROID_PLATFORM=android-16 \
+    -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${NINJA_OUTPUT}/obj \
+    -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${NINJA_OUTPUT}/obj \
+    -DCMAKE_MAKE_PROGRAM=${ANDROID_HOME}/cmake/${CMAKE_VERSION}/bin/ninja \
+    -DRUST_RELEASE=ON \
+    -DRUST_DEBUG_LOGS=OFF \
+    -DLIB_DEB_SYMBOLS=OFF \
+    -B${NINJA_OUTPUT} \
+    -GNinja
+
+# Run Ninja build
+${CMAKE_BIN} --build ${NINJA_OUTPUT} --target cargo-build

--- a/.github/rust-toolchain-android.toml
+++ b/.github/rust-toolchain-android.toml
@@ -1,0 +1,11 @@
+# Overrides used Rust toolchain by ./native submodule
+# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[toolchain]
+channel = "1.51.0"
+components = ["rustfmt", "clippy", "rls", "rust-analysis"]
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+]

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,0 +1,129 @@
+name: Check PR
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  filter_paths:
+    name: Filter changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      src_changed: ${{ steps.check_files.outputs.src_files }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: dorny/paths-filter@v2.10.1
+        id: check_files
+        with:
+          filters: |
+            src_files:
+              - '.cargo/**'
+              - '.github/workflows/*.yml'
+              - '.github/rust-toolchain-*.toml'
+              - '.github/*.sh'
+              - 'src/**'
+              - 'test/**'
+              - 'Cargo.*'
+              - 'CMakeLists.txt'
+
+  fetch_crates:
+    name: Prefetch Cargo crates
+    runs-on: ubuntu-latest
+    if: ${{ needs.filter_paths.outputs.src_changed == 'true' }}
+    needs: filter_paths
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Copy rust-toolchain file
+        run: |
+          cp ./.github/rust-toolchain-android.toml ./rust-toolchain
+
+      - name: Cache Cargo crates registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock', 'rust-toolchain') }}
+
+      - name: Run Cargo fetch
+        run: cargo fetch
+
+  test:
+    name: PR test Rust code
+    runs-on: ubuntu-latest
+    needs: fetch_crates
+    steps:
+      - name: Install packages
+        run: sudo apt install autopoint libleptonica-dev
+
+      - uses: actions/checkout@v2
+
+      - name: Copy rust-toolchain file
+        run: |
+          cp ./.github/rust-toolchain-android.toml ./rust-toolchain
+
+      - name: Cache Cargo crates registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock', 'rust-toolchain') }}
+
+      - name: Cache Cargo target
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./native/target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock', 'rust-toolchain') }}
+
+      - name: Run Rust tests
+        run: cargo test
+
+  build:
+    name: PR build Android shared libraries
+    runs-on: ubuntu-latest
+    needs: fetch_crates
+    strategy:
+      matrix:
+        abi: [arm64-v8a, armeabi-v7a, x86, x86_64]
+    env:
+      NDK_VERSION: 21.4.7075529
+      CMAKE_VERSION: 3.10.2.4988404
+      ABI: ${{ matrix.abi }}
+    steps:
+      - name: Install packages
+        run: sudo apt install autopoint
+
+      - uses: actions/checkout@v2
+
+      - name: Copy rust-toolchain file
+        run: |
+          cp ./.github/rust-toolchain-android.toml ./rust-toolchain
+
+      # Ensure that required packages are installed
+      - name: Prepare Android SDK
+        run: |
+          ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}" "cmake;${CMAKE_VERSION}" --channel=0
+
+      - name: Cache Cargo crates registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock', 'rust-toolchain') }}
+
+      - name: Cache Cargo target
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./native/target
+          key: ${{ runner.os }}-cargo-android-${{ env.ABI }}-${{ hashFiles('Cargo.lock', 'rust-toolchain') }}
+
+      - name: Build CMake target
+        run: |
+          ./.github/run_cmake.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ string(REPLACE "-" "_" CARGO_TARGET_TRIPPLE ${RUST_TARGET_TRIPPLE})
 string(TOUPPER ${CARGO_TARGET_TRIPPLE} CARGO_TARGET_TRIPPLE)
 
 # Cargo command
-set(CARGO_COMMAND ${CARGO} build --target=${RUST_TARGET_TRIPPLE} --features \"${RUST_BUILD_FEATURES}\")
+list(APPEND CARGO_COMMAND ${CARGO} build --target=${RUST_TARGET_TRIPPLE} --features "${RUST_BUILD_FEATURES}")
 
 # C/CXX flags
 set(C_FLAGS ${CMAKE_C_FLAGS} ${CMAKE_SHARED_LIBRARY_C_FLAGS})
@@ -112,7 +112,6 @@ else()
     set(RustBuildType debug)
 endif()
 
-list_to_spaced_string(CARGO_COMMAND)
 list_to_spaced_string(RUST_FLAGS)
 list_to_spaced_string(C_FLAGS)
 list_to_spaced_string(CXX_FLAGS)
@@ -121,82 +120,52 @@ list_to_spaced_string(CXX_FLAGS)
 set(CC "${ANDROID_TOOLCHAIN_ROOT}/bin/${CLANG_TRIPPLE}${ANDROID_NATIVE_API_LEVEL}-clang")
 set(CXX "${CC}++")
 
-function(create_script)
-    set(TMP_DIR tmp)
-    set(CARGO_BUILD_SCRIPT "${TMP_DIR}/cargo_build.sh")
-
-    file(MAKE_DIRECTORY ${TMP_DIR})
-
-    # Script will be placed into {ANDROID_MODULE}/.cxx/cmake/{ANDROID_VARIANT}/{ANDROID_ABI_NAME}/
-
-    set(CARGO_BUILD_SCRIPT_CONTENT
-"#!/bin/sh
-
 # Set required env variables
+list(APPEND CARGO_ENVS
+    # Set libc linker and ar
+    # You can also set specific flags by CXX_${abi.rustTriple} (CXX_i686-linux-android)
+    # https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables
+    "CC=${CC}"
+    "CXX=${CXX}"
+    "AR=${CMAKE_AR}"
+    "LD=${CMAKE_LINKER}"
+    "STRIP=${CMAKE_STRIP}"
+    "LLVM_CONFIG_PATH=${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-config"
+    # Setup cargo. It can be overrided via .cargo/config TOML file
+    # https://doc.rust-lang.org/cargo/reference/config.html
+    "CARGO_TARGET_${CARGO_TARGET_TRIPPLE}_LINKER=${CXX}"
+    "CARGO_TARGET_${CARGO_TARGET_TRIPPLE}_AR=${CMAKE_AR}"
+    # This will override your rustflags value in a .cargo/config file
+    "RUSTFLAGS=${RUST_FLAGS}"
+    # C/CXX flags
+    "CFLAGS=${C_FLAGS}"
+    "CXXFLAGS=${CXX_FLAGS}"
+    "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
+    # Passed to cc crate. Needed for Android. Without it cc crate will use c++_shared by default
+    # https://github.com/alexcrichton/cc-rs#c-support
+    "CXXSTDLIB=${ANDROID_STL}"
+    # CMAKE arguments
+    # https://developer.android.com/ndk/guides/cmake#usage
+    "CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+    "ANDROID_ABI=${ANDROID_ABI}"
+    "ANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL}"
+)
 
-# Set libc linker and ar
-# You can also set specific flags by CXX_${abi.rustTriple} (CXX_i686-linux-android)
-# https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables
+add_custom_target(
+    cargo-build
+    COMMENT "Run Rust Cargo build for Seeneva native library"
+    WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+    VERBATIM
+    USES_TERMINAL
+    COMMAND ${CMAKE_COMMAND} -E env ${CARGO_ENVS} ${CARGO_COMMAND}
+)
 
-export CC=\"${CC}\"
-export CXX=\"${CXX}\"
-export AR=\"${CMAKE_AR}\"
-export LD=\"${CMAKE_LINKER}\"
-export STRIP=\"${CMAKE_STRIP}\"
-export LLVM_CONFIG_PATH=\"${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-config\"
-
-# Setup cargo. It can be overrided via .cargo/config TOML file
-# https://doc.rust-lang.org/cargo/reference/config.html
-
-export CARGO_TARGET_${CARGO_TARGET_TRIPPLE}_LINKER=\"${CXX}\"
-export CARGO_TARGET_${CARGO_TARGET_TRIPPLE}_AR=\"${CMAKE_AR}\"
-
-# This will override your rustflags value in a .cargo/config file
-
-export RUSTFLAGS=\"${RUST_FLAGS}\"
-
-# C/CXX flags
-
-export CFLAGS=\"${C_FLAGS}\"
-export CXXFLAGS=\"${CXX_FLAGS}\"
-export LDFLAGS=\"${CMAKE_SHARED_LINKER_FLAGS}\"
-# Passed to cc crate. Needed for Android. Without it cc crate will use c++_shared by default
-# https://github.com/alexcrichton/cc-rs#c-support
-export CXXSTDLIB=\"${ANDROID_STL}\"
-
-# CMAKE arguments
-# https://developer.android.com/ndk/guides/cmake#usage
-
-export CMAKE_TOOLCHAIN_FILE=\"${CMAKE_TOOLCHAIN_FILE}\"
-export ANDROID_ABI=\"${ANDROID_ABI}\"
-export ANDROID_NATIVE_API_LEVEL=\"${ANDROID_NATIVE_API_LEVEL}\"
-
-echo 'Run cargo build for ${ANDROID_ABI}'
-
-cd ${CMAKE_HOME_DIRECTORY} && \\
-${CARGO_COMMAND}"
-    )
-
-    if(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-        set(CARGO_BUILD_SCRIPT_CONTENT
-"${CARGO_BUILD_SCRIPT_CONTENT} && \\
-mkdir -p ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} && \\
-# Copy shared libraries into output directory
-cp ./target/${RUST_TARGET_TRIPPLE}/${RustBuildType}/*.so ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
-        )
-    endif()
-
-    file(WRITE ${CARGO_BUILD_SCRIPT} ${CARGO_BUILD_SCRIPT_CONTENT})
-
-    file(
-        COPY ${CARGO_BUILD_SCRIPT}
-        DESTINATION ${CMAKE_BINARY_DIR}
-        NO_SOURCE_PERMISSIONS
-        FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-    )
-
-
-    file(REMOVE_RECURSE ${TMP_DIR})
-endfunction()
-
-create_script()
+add_custom_command(
+    TARGET cargo-build POST_BUILD
+    WORKING_DIRECTORY "${CMAKE_HOME_DIRECTORY}"
+    COMMENT "Copy shared libraries into output directory"
+    # Make output directory if it doesn't exist
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+    # Copy builded shared libraries
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "./target/${RUST_TARGET_TRIPPLE}/${RustBuildType}/*.so" "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+)


### PR DESCRIPTION
Bash script generation was removed from the`CMakeLists.txt` file. Now you can use the `cargo-build` CMake target to build Android shared library.